### PR TITLE
Switching to safe casting method for Double instead of TimeInterval

### DIFF
--- a/Server/rainbow-server/.swiftlint.yml
+++ b/Server/rainbow-server/.swiftlint.yml
@@ -1,0 +1,13 @@
+disabled_rules:
+  - line_length
+file_length:
+  warning: 600
+  error: 1000
+included: # paths to include during linting. `--path` is ignored if present.
+  - ./Sources
+excluded:
+  # put paths for excluded swiftlint files here
+type_body_length:
+  - 300 # warning
+  - 400 # error
+reporter: "xcode"

--- a/Server/rainbow-server/Sources/Application/Application.swift
+++ b/Server/rainbow-server/Sources/Application/Application.swift
@@ -14,8 +14,8 @@ public let projectPath = ConfigurationManager.BasePath.project.path
 public let health = Health()
 
 enum ServiceInitializationError: Error {
-    case CloudantError(String)
-    case PushNotificationError(String)
+    case cloudantError(String)
+    case pushNotificationError(String)
 }
 
 public class ApplicationServices {
@@ -27,10 +27,10 @@ public class ApplicationServices {
         // Run service initializers
         do {
             couchDBService = try initializeServiceCloudant(cloudEnv: cloudEnv)
-        } catch ServiceInitializationError.CloudantError(let reason) {
+        } catch ServiceInitializationError.cloudantError(let reason) {
             Log.error("Error setting up Cloudant: \(reason)")
             couchDBService = nil
-        } catch ServiceInitializationError.PushNotificationError(let reason) {
+        } catch ServiceInitializationError.pushNotificationError(let reason) {
             Log.error("Error setting up Push Notifications: \(reason)")
         } catch {
             couchDBService = nil

--- a/Server/rainbow-server/Sources/Application/Model/ScoreEntry+SwiftyJSON.swift
+++ b/Server/rainbow-server/Sources/Application/Model/ScoreEntry+SwiftyJSON.swift
@@ -29,7 +29,7 @@ extension ScoreEntry {
         }
         objects = objectEntries
     }
-    
+
     mutating func toJSONDocument() -> JSON? {
         guard let avatarImage = self.avatarImage else {
             // we need to discuss how to proceed if there is no avatar - my guess is to bail
@@ -37,7 +37,11 @@ extension ScoreEntry {
         }
         self.avatarURL = AvatarObjectStorage.save(image: avatarImage, to: nil)
         self.avatarImage = nil
-        let encoded = try! JSONEncoder().encode(self)
-        return JSON(data: encoded)
+        do {
+            let encoded = try JSONEncoder().encode(self)
+            return JSON(data: encoded)
+        } catch {
+            return nil
+        }
     }
 }

--- a/Server/rainbow-server/Sources/Application/Services/ServicePush.swift
+++ b/Server/rainbow-server/Sources/Application/Services/ServicePush.swift
@@ -4,7 +4,7 @@ import IBMPushNotifications
 
 func initializeServicePush(cloudEnv: CloudEnv) throws -> PushNotifications {
     guard let pushNotificationsCredentials = cloudEnv.getPushSDKCredentials(name: "push") else {
-        throw ServiceInitializationError.PushNotificationError("Could not load credentials for Push Notifications.")
+        throw ServiceInitializationError.pushNotificationError("Could not load credentials for Push Notifications.")
     }
     let pushNotifications = PushNotifications(
         pushRegion: pushNotificationsCredentials.region,

--- a/Server/rainbow-server/Sources/Application/SwiftyJSONUtil.swift
+++ b/Server/rainbow-server/Sources/Application/SwiftyJSONUtil.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftyJSON
+import LoggerAPI
 
 class Formatter {
     private static var internalJsonDateTimeFormatter: DateFormatter?
@@ -46,11 +47,14 @@ extension Date {
 // MARK: - JSON dateTime
 extension JSON {
     public var dateTime: Date? {
+        Log.debug("Converting JSON to datetime object")
         switch type {
         case .string:
-            return Formatter.jsonDateTimeFormatter.date(from: object as! String)
+            Log.debug("Detected string: \(self.stringValue)")
+            return Formatter.jsonDateTimeFormatter.date(from: self.stringValue)
         case .number:
-            return Date(timeIntervalSinceReferenceDate: object as! TimeInterval)
+            Log.debug("Detected number: \(String(describing: self.doubleValue))")
+            return Date(timeIntervalSinceReferenceDate: self.doubleValue)
         default:
             return nil
         }

--- a/Server/rainbow-server/Sources/rainbow-server/main.swift
+++ b/Server/rainbow-server/Sources/rainbow-server/main.swift
@@ -5,9 +5,7 @@ import HeliumLogger
 import Application
 
 do {
-
     HeliumLogger.use(LoggerMessageType.info)
-
     let app = try App()
     try app.run()
 

--- a/iOS/rainbow.xcodeproj/project.pbxproj
+++ b/iOS/rainbow.xcodeproj/project.pbxproj
@@ -255,7 +255,7 @@
 				533818FA209757B900DE66CB /* Sources */,
 				533818FB209757B900DE66CB /* Frameworks */,
 				533818FC209757B900DE66CB /* Resources */,
-				5338193220975A1200DE66CB /* ShellScript */,
+				5338193220975A1200DE66CB /* Swiftlint */,
 				5338193820975C2100DE66CB /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -374,13 +374,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		5338193220975A1200DE66CB /* ShellScript */ = {
+		5338193220975A1200DE66CB /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = Swiftlint;
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Fixes #16 

Was previously using an unsafe casting method from `Any` to `TimeInterval`, which Linux didn't like.