### PR TITLE
Updated app to use new version of Lumina

### DIFF
--- a/iOS/rainbow/Config/Info.plist
+++ b/iOS/rainbow/Config/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/iOS/rainbow/Controller/Camera/CameraController.swift
+++ b/iOS/rainbow/Controller/Camera/CameraController.swift
@@ -37,7 +37,7 @@ class CameraController: LuminaViewController {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.delegate = self
-        self.streamingModelTypes = [ProjectRainbowModel_1753554316()]
+        self.streamingModels = [LuminaModel(model: ProjectRainbowModel_1753554316().model, type: "WatsonML")]
         self.setShutterButton(visible: false)
         self.setTorchButton(visible: true)
         self.setCancelButton(visible: false)
@@ -104,7 +104,6 @@ class CameraController: LuminaViewController {
                 continueGame()
             }
         } catch {
-//            NotificationCenter.default.post(name: Notification.Name("viva-ml-device-token-registered"), object: "00000000-0000-0000-0000-000000000000")
             showStartView()
         }
     }


### PR DESCRIPTION
Lumina now takes Core ML models as input in a different way that allows for us to use the Watson Visual Recognition service to update the model remotely if we so choose. I have not updated the app to do this yet as we need to have an architecture discussion, but the app now works as it used to with an updated call to Lumina.