### PR TITLE
Will only update score entry on game start if its the first time

### DIFF
--- a/iOS/rainbow/Controller/Camera/CameraController.swift
+++ b/iOS/rainbow/Controller/Camera/CameraController.swift
@@ -110,18 +110,29 @@ class CameraController: LuminaViewController {
     }
     
     func startNewGame() {
+        defer {
+            continueGame()
+        }
+        var needsServerUpdate = true
         do {
             for view in iconCheckImageViews {
                 view.1.alpha = 0.0
             }
             var savedScoreEntry = try ScoreEntry.ClientPersistence.get()
+            if savedScoreEntry.finishDate != nil {
+                needsServerUpdate = false
+            }
             savedScoreEntry.startDate = Date()
             savedScoreEntry.finishDate = nil
             savedScoreEntry.objects = nil
             try ScoreEntry.ClientPersistence.save(entry: savedScoreEntry)
             cachedScoreEntry = savedScoreEntry
             
+            if needsServerUpdate == false {
+                return
+            }
             //we don't want to send base64 string
+            
             savedScoreEntry.avatarImage = nil
             
             //update the startDate to the cloud.            
@@ -138,7 +149,6 @@ class CameraController: LuminaViewController {
                     print("Successfully updated cloud database with startDate \(String(describing: entry.startDate))")
                 }
             })
-            continueGame()
         } catch {
             SVProgressHUD.showError(withStatus: "Couldn't connect to the server - keep playing!")
         }


### PR DESCRIPTION
I've made a change that allows for entries to never be deleted from the leaderboard once they're live. This is the logic:

- if the user is starting a new game, and its the first time, then the server will update the record.
- if the user is starting a new game, and it's not the first time, the server will not find out about the new game, so the leaderboard entry will be retained.